### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/src/backend/magentic_one_helper.py
+++ b/src/backend/magentic_one_helper.py
@@ -243,8 +243,9 @@ class MagenticOneHelper:
                         "content": str(event)
                     }
             except Exception as e:
+                logging.error(f"Error processing event: {str(e)}")
                 yield {
                     "type": "error",
                     "source": "system",
-                    "content": f"Error processing event: {str(e)}"
+                    "content": "An internal error has occurred."
                 }

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -356,7 +356,7 @@ async def run_task(task: str, background_tasks: BackgroundTasks) -> Dict[str, An
             "Error starting task",
             {"error": str(e)}
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error has occurred.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes [https://github.com/Qredence/AgenticFleet/security/code-scanning/2](https://github.com/Qredence/AgenticFleet/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception messages and stack traces are not exposed to the end user. Instead, we should log the detailed error messages on the server and return a generic error message to the client. This can be achieved by modifying the exception handling in the `stream_output` function and the `run_task` endpoint.

1. Modify the `stream_output` function to log detailed error messages and yield a generic error message.
2. Modify the `run_task` endpoint to raise an `HTTPException` with a generic error message instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
